### PR TITLE
[BOJ] 레이저 통신

### DIFF
--- a/BOJ/레이저 통신/박상민.cpp
+++ b/BOJ/레이저 통신/박상민.cpp
@@ -1,0 +1,95 @@
+#include <iostream>
+#include <queue>
+#include <memory.h>
+#include <cmath>
+using namespace std;
+
+typedef pair<int, int> cod;
+
+char map[100][100];
+int mir[100][100];
+
+struct el{
+  int dir;
+  int r;
+  int c;
+  int mirror;
+};
+
+struct compare{
+  bool operator()(struct el a, struct el b){
+    return a.mirror > b.mirror;
+  }
+};
+
+int main(){
+  cod move[4] = {{0, -1}, {1, 0}, {0, 1}, {-1, 0}};
+  int col, row;
+  queue<cod> laserlist;
+  priority_queue<struct el, vector<struct el>, compare> search;
+
+  memset(mir, 0x3f, sizeof(mir));
+
+  cin >> col >> row;
+
+  for(int rdx = 0; rdx < row; rdx++){
+    cin >> map[rdx];
+    for(int cdx = 0; cdx < col; cdx++){
+      if(map[rdx][cdx] == 'C')
+        laserlist.push({rdx, cdx});
+    }
+  }
+
+  cod src = laserlist.front();
+  laserlist.pop();
+  mir[src.first][src.second] = 0;
+  cod dst = laserlist.front();
+
+  for(int ddx = 0; ddx < 4; ddx++){
+    cod next = {src.first + move[ddx].first, src.second + move[ddx].second};
+
+    if(next.first < 0 || next.second < 0 || next.first >= row || next.second >= col)
+      continue;
+
+    if(map[next.first][next.second] == '*')
+      continue;
+
+    struct el added = {ddx, next.first, next.second, 0};
+    search.push(added);
+    mir[next.first][next.second] = 0;
+  }
+
+  while(!search.empty()){
+    struct el curr = search.top();
+    search.pop();
+
+    if(curr.r == dst.first && curr.c == dst.second)
+      break;
+
+    if(mir[curr.r][curr.c] < curr.mirror)
+      continue;
+
+    for(int ddx = 0; ddx < 4; ddx++){
+      if(ddx == (curr.dir + 2) % 4)
+        continue;
+      cod next = {curr.r + move[ddx].first, curr.c + move[ddx].second};
+      int next_mir;
+
+      if(next.first < 0 || next.second < 0 || next.first >= row || next.second >= col)
+        continue;
+
+      if(map[next.first][next.second] == '*')
+        continue;
+
+      next_mir = (ddx == curr.dir)? curr.mirror : curr.mirror + 1;
+
+      if(next_mir <= mir[next.first][next.second]){
+        struct el added = {ddx, next.first, next.second, next_mir};
+        search.push(added);
+        mir[next.first][next.second] = next_mir;
+      }
+    }
+  }
+
+  cout << mir[dst.first][dst.second];
+}

--- a/BOJ/레이저 통신/박상민.cpp
+++ b/BOJ/레이저 통신/박상민.cpp
@@ -1,95 +1,90 @@
 #include <iostream>
 #include <queue>
 #include <memory.h>
-#include <cmath>
 using namespace std;
+typedef pair<int, int> rc;
 
-typedef pair<int, int> cod;
-
+/* character 2D array for space status */
 char map[100][100];
+/* integer 2D array for minimum # of mirror to reach position */
 int mir[100][100];
-
-struct el{
-  int dir;
-  int r;
-  int c;
-  int mirror;
-};
-
+/* unit for search */
+struct el{int dir; int r; int c; int mirror;};
+/* compare function for priority_queue */
 struct compare{
-  bool operator()(struct el a, struct el b){
+  bool operator()(struct el &a, struct el &b){
     return a.mirror > b.mirror;
   }
 };
+/* coordinate validity check function for bfs search */
+bool range_check(int &row, int &col, rc &curr){
+  return (curr.first < 0 || curr.second < 0 || curr.first >= row || curr.second >= col);
+}
 
 int main(){
-  cod move[4] = {{0, -1}, {1, 0}, {0, 1}, {-1, 0}};
-  int col, row;
-  queue<cod> laserlist;
+  rc move[4] = {{0, -1}, {1, 0}, {0, 1}, {-1, 0}};
+  int row, col, count = 0;
+  rc src, dst;
   priority_queue<struct el, vector<struct el>, compare> search;
-
   memset(mir, 0x3f, sizeof(mir));
 
   cin >> col >> row;
-
   for(int rdx = 0; rdx < row; rdx++){
     cin >> map[rdx];
     for(int cdx = 0; cdx < col; cdx++){
-      if(map[rdx][cdx] == 'C')
-        laserlist.push({rdx, cdx});
+      if(map[rdx][cdx] == 'C'){
+        if(count++ == 0)
+          src = {rdx, cdx};
+        else
+          dst = {rdx, cdx};
+      }
     }
   }
 
-  cod src = laserlist.front();
-  laserlist.pop();
+  /* push initial elements to search queue */
   mir[src.first][src.second] = 0;
-  cod dst = laserlist.front();
-
   for(int ddx = 0; ddx < 4; ddx++){
-    cod next = {src.first + move[ddx].first, src.second + move[ddx].second};
+    rc next = {src.first + move[ddx].first, src.second + move[ddx].second};
 
-    if(next.first < 0 || next.second < 0 || next.first >= row || next.second >= col)
+    if(range_check(row, col, next))
       continue;
-
     if(map[next.first][next.second] == '*')
       continue;
 
-    struct el added = {ddx, next.first, next.second, 0};
-    search.push(added);
+    struct el to_add = {ddx, next.first, next.second, 0};
+    search.push(to_add);
     mir[next.first][next.second] = 0;
   }
 
   while(!search.empty()){
     struct el curr = search.top();
     search.pop();
-
+    /* found the other laser! hurray */
     if(curr.r == dst.first && curr.c == dst.second)
       break;
-
+    /* if not recently updated one */
     if(mir[curr.r][curr.c] < curr.mirror)
       continue;
 
     for(int ddx = 0; ddx < 4; ddx++){
+      /* unreachable if opposite direction */
       if(ddx == (curr.dir + 2) % 4)
         continue;
-      cod next = {curr.r + move[ddx].first, curr.c + move[ddx].second};
-      int next_mir;
+      rc next = {curr.r + move[ddx].first, curr.c + move[ddx].second};
 
-      if(next.first < 0 || next.second < 0 || next.first >= row || next.second >= col)
+      if(range_check(row, col, next))
         continue;
-
       if(map[next.first][next.second] == '*')
         continue;
 
-      next_mir = (ddx == curr.dir)? curr.mirror : curr.mirror + 1;
+      int next_mir = (ddx == curr.dir)? curr.mirror : curr.mirror + 1;
 
       if(next_mir <= mir[next.first][next.second]){
-        struct el added = {ddx, next.first, next.second, next_mir};
-        search.push(added);
+        struct el to_add = {ddx, next.first, next.second, next_mir};
+        search.push(to_add);
         mir[next.first][next.second] = next_mir;
       }
     }
   }
-
   cout << mir[dst.first][dst.second];
 }


### PR DESCRIPTION
<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #6 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의

Input : W (열의 갯수), H (행의 갯수), 문자열 H개
- 1 ≤ W, H ≤ 100
- 각 문자열은 H번째 행의 상태를 가리킴 (* for wall, C for laser, . for empty)

Output :
두 개의 레이저를 연결하기 위한 거울의 최소 갯수

<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계

다익스트라
- 특정 좌표까지 도달하기 위한 거울의 갯수를 기준으로 다익스트라를 시행합니다. 
- 거울의 갯수가 같거나 적을 때 해당 상태를 우선순위 큐에 삽입합니다. 
  (거울의 갯수가 같아도 방향에 따라 추후 업데이트에 영향을 줌)
- 현 코드는 한 칸씩 전진하며 업데이트를 수행하지만, 같은 방향에 대해서 행/열 별로 일괄 처리를 할 경우 더 빠른 구현이 가능할 것 같습니다. 

### 🥝 최악 수행 시간 복잡도
HW*Log(HW)

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
