### PR TITLE
[BOJ] 레이저 통신

### DIFF
--- a/BOJ/레이저 통신/박예찬.cpp
+++ b/BOJ/레이저 통신/박예찬.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include<string>
+#include<queue>
+#include<tuple>
+#include<vector>
+using namespace std;
+bool flag[101][101];
+int counter[101][101];
+char arr[101][101];
+int n, m;
+int mir;
+int start[2];
+int dest[2];
+bool findStart;
+int dx[] = { -1,1,0,0 };
+int dy[] = { 0,0,-1,1 };
+int main() {
+	ios_base::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+	cin >> m >> n;
+	for (int i = 1; i <= n; i++) {
+		for (int j = 1; j <= m; j++) {
+			cin >> arr[i][j];
+			if (arr[i][j] == 'C') {
+				if (!findStart) {
+					start[0] = i;
+					start[1] = j;
+					findStart = true;
+				}
+				else {
+					dest[0] = i;
+					dest[1] = j;
+				}
+			}
+		}
+	}
+	priority_queue<tuple<int, int, int,int>, vector<tuple<int, int, int,int>>, greater<tuple<int, int, int,int>>> pq;
+	pq.push({ 0,start[0],start[1],-1 });
+	while (!pq.empty()) {
+		int a = get<0>(pq.top());
+		int b = get<1>(pq.top());
+		int c = get<2>(pq.top());
+		int d = get<3>(pq.top());
+		pq.pop();
+		if (flag[b][c]&&counter[b][c]<a) {
+			continue; 
+		}
+		flag[b][c] = true;
+		counter[b][c] = a;
+		for (int i = 0; i < 4; i++) {
+			int x = b+dx[i];
+			int y = c + dy[i];
+			if (x<1 || y<1 || x>n || y>m||arr[x][y]=='*')continue;
+			if (d == -1) {
+				pq.push({ a,x,y,i });
+			}
+			else {
+				if (d == i) {
+					pq.push({ a,x,y,i });
+				}
+				else {
+					pq.push({ a+1,x,y,i });
+				}
+			}
+		}
+	}
+	cout << counter[dest[0]][dest[1]];
+}


### PR DESCRIPTION
BFS를 이용해서 문제 해결

<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #6



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
Input : 열과 행, 각 배열에 들어갈 문자(벽은  '*', 벽이 아닌 길은 '.' ,도착점과 시작점은 'C'로 입력
Output : C와 C가 만나기 위해 필요한 최소한의 거울의 갯수


<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계

입력받은 후 원하는 좌표까지 가는데 이전과 같은 방향이라면 거울이 필요가 없으므로 거울의 갯수를 그대로, 방향이 다르다면 거울의 갯수를 1더해주는 방식으로 BFS를 진행
거울의 갯수를 더 적게 이용해 갈 수 있는 방법이 있다면 그 방법으로 초기화 해줌
우선순위 큐를 사용해 거울의 수가 적을 때 연산을 먼저 하도록 진행


### 🥝 최악 수행 시간 복잡도
NM(logNM)

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
