### PR TITLE
[BOJ] 탈옥

### DIFF
--- a/BOJ/탈옥/김선필.cpp
+++ b/BOJ/탈옥/김선필.cpp
@@ -1,0 +1,121 @@
+﻿#include <iostream>
+#include <vector>
+#include <deque>
+
+using namespace std;
+
+const int INF = 1e5;
+const char WALL = '*';
+const char DOOR = '#';
+const char PRISONER = '$';
+const char VACANT = '.';
+
+const int dr[] = {-1, 0, 1, 0};
+const int dc[] = {0, 1, 0, -1};
+
+vector<vector<int>> BFS(const vector<vector<char>>& map, const pair<int, int>& start) {
+	const int& n = map.size();
+	const int& m = map[0].size();
+
+	vector<vector<int>> dp(n, vector<int>(m, INF));
+	dp[start.first][start.second] = 0;
+
+	deque<pair<int, pair<int, int>>> dq;
+	dq.emplace_back(0, make_pair(start.first, start.second));
+
+	while (!dq.empty()) {
+		const int cost = dq.front().first;
+		const int row = dq.front().second.first;
+		const int col = dq.front().second.second;
+		dq.pop_front();
+
+		if (dp[row][col] < cost) {
+			continue;
+		}
+
+		for (int i = 0; i < 4; i++) {
+			const int next_row = row + dr[i];
+			const int next_col = col + dc[i];
+			if (next_row < 0 || next_row >= n || next_col < 0 || next_col >= m) {
+				continue;
+			}
+
+			const char& room_type = map[next_row][next_col];
+			if (room_type == WALL) {
+				continue;
+			}
+
+			int new_cost = cost;
+			int& next_cost = dp[next_row][next_col];
+			if (room_type == DOOR) {
+				if (next_cost <= ++new_cost) {
+					continue;
+				}
+				dq.emplace_back(new_cost, make_pair(next_row, next_col));
+			}
+			else {
+				if (next_cost <= new_cost) {
+					continue;
+				}
+				dq.emplace_front(new_cost, make_pair(next_row, next_col));
+			}
+
+			next_cost = min(next_cost, new_cost);
+		}
+	}
+
+	return dp;
+}
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(nullptr);
+
+	int T;
+	cin >> T;
+	
+	while (T--) {
+		int h, w;
+		cin >> h >> w;
+
+		vector<pair<int, int>> prisoners;
+		vector<vector<char>> map(h + 2, vector<char>(w + 2, VACANT));
+		for (int i = 1; i <= h; i++) {
+			string input;
+			cin >> input;
+			
+			for (int j = 1; j <= w; j++) {
+				map[i][j] = input[j - 1];
+				if (map[i][j] == PRISONER) {
+					prisoners.emplace_back(i, j);
+				}
+			}
+		}
+		prisoners.emplace_back(0, 0);
+
+		vector<vector<vector<int>>> dp(3);
+		for (int i = 0; i < 3; i++) {
+			dp[i] = BFS(map, prisoners[i]);
+		}
+
+		int answer = INF;
+		for (int i = 1; i <= h; i++) {
+			for (int j = 1; j <= w; j++) {
+				if (map[i][j] == WALL) {
+					continue;
+				}
+
+				if (map[i][j] == DOOR) {
+					answer = min(answer, dp[0][i][j] + dp[1][i][j] + dp[2][i][j] - 2);
+				}
+				else {
+					answer = min(answer, dp[0][i][j] + dp[1][i][j] + dp[2][i][j]);
+				}
+			}
+		}
+
+		cout << answer << '\n';
+	}
+	
+	return 0;
+}


### PR DESCRIPTION
<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #24 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
#### ✔ Input 정의
- 테스트 케이스 T[1, 100]
- 평면도의 높이 h, 너비 w [2, 100]
- 평면도 정보
    - 빈 공간: `.`
    - 지나갈 수 없는 벽: `*`
    - 문: `#`
    - 죄수의 위치: `$`

#### ✔ Output 정의
- 각 테스트 케이스마다 두 죄수를 탈옥시키기 위해 열어야 하는 문의 최솟값 구하기

<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계
`0-1 BFS` 알고리즘과 `DP` 테크닉을 이용하여 해결하였습니다.
> p.s) 가중치의 종류가 두 가지인 경우, 자료구조 deque를 이용하여 O(1)에 정렬할 수 있습니다.

- 이 문제는 3가지 경우의 수를 따져보아야 합니다.
    1. 두 죄수의 탈출 경로가 겹치지 않게 각각 다른 문으로 탈출하는 경우
    2. 죄수 A가 죄수 B의 위치로 이동해서 함께 같은 문으로 탈출하는 경우
    3. 두 죄수가 어느 한 지점에서 만나 함께 같은 문으로 탈출하는 경우 <br><br>
    
    - 1번과 2번의 경우는 각각 두 죄수의 위치를 시작점으로 0-1 BFS를 수행하여, 각 지점까지 이동하는데 열은 문의 최소 개수를 메모이제이션하면서 쉽게 구할 수 있습니다.
    - 3번의 경우는 모든 지점에 대해 한 번씩 두 죄수가 중간에 만나는 지점으로 설정해 보고, 해당 지점에서 다시 탈출구로 나가는 길을 찾아야 합니다.
- 위의 아이디어는 금방 떠올릴 수 있었지만, 중간 지점마다 0-1 BFS를 돌려봐야 하는 문제와, 탈출구로 나가는 길에서 또 다시 지나왔던 경로도 생각해야 하는 등, 구현이 매우 복잡해서 조금 **다른 아이디어**를 이용하였습니다.
    - 모든 지점에 대해 각각 한 번씩 중간 지점으로 설정해 봅니다.
    - (1. `두 죄수가 중간 지점에서 만나`) (2. `함께 동일한 경로로 탈출하는 것`)
        - 2번의 경우 반대로 생각해 보면, (`다른 죄수가 평면도 밖에서 중간 지점으로 들어오는 경우`)로 생각해도 문제가 없습니다.
- 따라서, 문제를 `세 명의 죄수가 중간 지점에 만나기 위해 열어야 하는 문의 최솟값 구하기`로 바꿔 생각해 보면, 훨씬 간단하게 해결할 수 있습니다.
    1. 먼저, 입력 받은 평면도의 테두리에 `빈 공간(.)`으로 채워준 다음, 세 번째 죄수의 위치를 `(0, 0)`으로 설정합니다.
    2. 세 명의 죄수에 대해 각각 0-1 BFS 알고리즘을 수행하면서 평면도의 각 지점에 대한 DP 배열을 얻어 옵니다.
    3. 평면도의 각 지점에 대해 세 명의 죄수가 해당 지점까지 도달하는데 열은 문의 최솟값을 더해 봅니다.
        - 이 때 해당 지점이 `문`이라면, 맨 처음에 도달한 사람이 한 번만 문을 열면 되므로 2를 빼줍니다.
    4. 위에서 계산한 값들 중 최솟값을 찾으면, 원래 구하고자 하는 답을 얻을 수 있습니다.

### 🥝 최악 수행 시간 복잡도
- `O(V + E)`
   - V: 정점 개수
   - E: 간선 개수

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
