### PR TITLE
[BOJ] 말이 되고픈 원숭이

### DIFF
--- a/BOJ/말이 되고픈 원숭이/박예찬.cpp
+++ b/BOJ/말이 되고픈 원숭이/박예찬.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include<vector>
+#include<queue>
+#include<algorithm>
+#include<tuple>
+using namespace std;
+int n, m, k;
+int counter[201][201][31];
+int arr[201][201];
+int dx[] = { 0,0,-1,1 };
+int dy[] = { 1,-1,0,0 };
+int jux[] = { 2,2,-2,-2,1,1,-1,-1 };
+int juy[] = { 1,-1,1,-1,2,-2,2,-2 };
+int max_ = 1000000000;
+int main() {
+	ios_base::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+	cin >> k >> n >> m;
+	for (int i = 1; i <= m; i++)
+		for (int j = 1; j <= n; j++)
+		{
+			cin >> arr[i][j];
+			for (int l = 0; l <= k; l++) {
+				counter[i][j][l] = max_;
+			}
+		}
+	counter[1][1][0] = 0;
+	queue<tuple<int, int, int>> q;
+	q.push({ 1,1,0});
+	while (!q.empty()) {
+		int x = get<0>(q.front());
+		int y = get<1>(q.front());
+		int z=  get<2>(q.front());
+		q.pop();
+		//cout << x << ' ' << y << ' ' << z << endl;
+		if (x == m && y == n) {
+			cout << counter[x][y][z];
+			return 0;
+		}
+		for (int i = 0; i < 4; i++) {		
+			int x2 = x + dx[i];
+			int y2 = y + dy[i];
+			if (arr[x2][y2] == 1||x2<1||y2<1||x2>m||y2>n)continue;
+			if (counter[x2][y2][z] > counter[x][y][z]+1) {
+				counter[x2][y2][z] = counter[x][y][z]+1;
+				q.push({ x2,y2,z});
+			}
+		}
+		if (z < k) {
+			for (int i = 0; i < 8; i++) {
+				int x2 = x + jux[i];
+				int y2 = y + juy[i];
+				if (arr[x2][y2] == 1 || x2<1 || y2<1 || x2>m|| y2>n)continue;
+				if (counter[x2][y2][z+1] > counter[x][y][z] + 1) {
+					counter[x2][y2][z+1] = counter[x][y][z] + 1;
+					q.push({ x2,y2,z+1});
+				}
+			}
+		}
+	}
+	cout << -1;
+}


### PR DESCRIPTION
BFS를 통해 문제 해결

<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #44 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
Input :K(말처럼 행동할 수 있는 최대 횟수) N,M (단 이 문제에서는 격자판의 x축이 n,y축이 m이므로 다른 문제들과 약간 다름)
격자판의 형태 (0이면 이동 가능, 1이면 장애물이 있어서 이동 불가능)


<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계
BFS를 통해 문제를 해결하였다.
x축과 y축뿐만 아니라, 현재 점프를 한 횟수까지 기억을 해서 점프를 한 횟수가 최대를 넘지 않으면 점프까지 탐색을 한다.
탐색한 곳의 X축,Y축,점프 횟수가 아직 탐색이 되지 않았거나, 이번에 탐색했을 때 더 적은 횟수로 갈 수 있다면 큐에 넣어주고, 그렇지 않다면 무시하면 된다.


### 🥝 최악 수행 시간 복잡도
O(NMK)

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
