### PR TITLE
[BOJ] 파티

### DIFF
--- a/BOJ/파티/박예찬.cpp
+++ b/BOJ/파티/박예찬.cpp
@@ -6,11 +6,12 @@
 using namespace std;
 int n, m, k;
 vector<pair<int, int>> v[1001];
-int dij[1001][1001];
-bool flag[1001][1001];
+vector<pair<int, int>> rev[1001];
+int dij[1001][2];
+bool flag[1001][2];
 int max_ = 1000000000;
 void dijkstra1(int s) {
-	priority_queue<pair<int, int>,vector<pair<int,int>>,greater<pair<int,int>>> pq; //{거리,목표 점}
+	priority_queue<pair<int, int>, vector<pair<int, int>>, greater<pair<int, int>>> pq; //{거리,목표 점}
 	pq.push({ 0,s });
 	dij[s][0] = 0;
 	while (!pq.empty()) {
@@ -29,34 +30,35 @@ void dijkstra1(int s) {
 		}
 	}
 }
-int dijkstra2(int s,int e) {
+void dijkstra2(int s) {
 	priority_queue<pair<int, int>, vector<pair<int, int>>, greater<pair<int, int>>> pq; //{거리,목표 점}
 	pq.push({ 0,s });
-	dij[s][s] = 0;
+	dij[s][1] = 0;
 	while (!pq.empty()) {
 		int x = pq.top().first;
 		int y = pq.top().second;
 		pq.pop();
-		if (flag[y][s]) continue;
-		flag[y][s] = true;
-		dij[y][s] = x;
-		if (y == e)return dij[y][s];
-		for (int i = 0; i < v[y].size(); i++) {
-			int d = x + v[y][i].second;
-			int dest = v[y][i].first;
-			if (dij[dest][s] > d) {
+		if (flag[y][1]) continue;
+		flag[y][1] = true;
+		dij[y][1] = x;
+		for (int i = 0; i < rev[y].size(); i++) {
+			int d = x + rev[y][i].second;
+			int dest = rev[y][i].first;
+			if (dij[dest][1] > d) {
 				pq.push({ d,dest });
 			}
 		}
 	}
 }
+
 int main() {
 	ios_base::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
 	cin >> n >> m >> k;
 	for (int i = 0; i < m; i++) {
-	int x, y, z;
-	cin >> x >> y >> z;
-    v[x].push_back({ y,z });
+		int x, y, z;
+		cin >> x >> y >> z;
+		v[x].push_back({ y,z });
+		rev[y].push_back({ x,z });
 	}
 	for (int i = 1; i <= n; i++) {
 		for (int j = 0; j <= n; j++) {
@@ -64,9 +66,10 @@ int main() {
 		}
 	}
 	dijkstra1(k);
+	dijkstra2(k);
 	int maxTime = 0;
 	for (int i = 1; i <= n; i++) {
-		int t=dij[i][0]+dijkstra2(i, k);
+		int t = dij[i][0] + dij[i][1];
 		//cout << t << endl;
 		if (t > maxTime) {
 			maxTime = t;

--- a/BOJ/파티/박예찬.cpp
+++ b/BOJ/파티/박예찬.cpp
@@ -1,0 +1,76 @@
+#include <iostream>
+#include<vector>
+#include<queue>
+#include<algorithm>
+#include<tuple>
+using namespace std;
+int n, m, k;
+vector<pair<int, int>> v[1001];
+int dij[1001][1001];
+bool flag[1001][1001];
+int max_ = 1000000000;
+void dijkstra1(int s) {
+	priority_queue<pair<int, int>,vector<pair<int,int>>,greater<pair<int,int>>> pq; //{거리,목표 점}
+	pq.push({ 0,s });
+	dij[s][0] = 0;
+	while (!pq.empty()) {
+		int x = pq.top().first;
+		int y = pq.top().second;
+		pq.pop();
+		if (flag[y][0]) continue;
+		flag[y][0] = true;
+		dij[y][0] = x;
+		for (int i = 0; i < v[y].size(); i++) {
+			int d = x + v[y][i].second;
+			int dest = v[y][i].first;
+			if (dij[dest][0] > d) {
+				pq.push({ d,dest });
+			}
+		}
+	}
+}
+int dijkstra2(int s,int e) {
+	priority_queue<pair<int, int>, vector<pair<int, int>>, greater<pair<int, int>>> pq; //{거리,목표 점}
+	pq.push({ 0,s });
+	dij[s][s] = 0;
+	while (!pq.empty()) {
+		int x = pq.top().first;
+		int y = pq.top().second;
+		pq.pop();
+		if (flag[y][s]) continue;
+		flag[y][s] = true;
+		dij[y][s] = x;
+		if (y == e)return dij[y][s];
+		for (int i = 0; i < v[y].size(); i++) {
+			int d = x + v[y][i].second;
+			int dest = v[y][i].first;
+			if (dij[dest][s] > d) {
+				pq.push({ d,dest });
+			}
+		}
+	}
+}
+int main() {
+	ios_base::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+	cin >> n >> m >> k;
+	for (int i = 0; i < m; i++) {
+	int x, y, z;
+	cin >> x >> y >> z;
+    v[x].push_back({ y,z });
+	}
+	for (int i = 1; i <= n; i++) {
+		for (int j = 0; j <= n; j++) {
+			dij[i][j] = max_;
+		}
+	}
+	dijkstra1(k);
+	int maxTime = 0;
+	for (int i = 1; i <= n; i++) {
+		int t=dij[i][0]+dijkstra2(i, k);
+		//cout << t << endl;
+		if (t > maxTime) {
+			maxTime = t;
+		}
+	}
+	cout << maxTime;
+}


### PR DESCRIPTION
다익스트라 알고리즘을 사용하여 문제 해결

<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #61 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
Input : 
마을의 개수 N, 경로 M, 파티가 열리는 마을 X
이후 M개의 줄마다
a마을에서 b마을로 가는데 걸리는 시간 c 를 입력
Output :
모든 마을중에서 X번 마을로 갔다가, 다시 본인 마을로 돌아가는데 걸리는 시간이 오래걸리는 마을

<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계

다익스트라 알고리즘을 여러번 사용하여 문제를 해결하였다.
~~먼저,파티가 열린 마을에서 각 마을까지의 최단거리를 구한 후  각 마을에서 파티가 열린 마을까지 최단거리를 구해준다.~~
먼저, 파티가 열린 마을에서 각 마을까지 최단거리를 구해준다.
또한, 각 마을에서 파티가 열린 마을까지의 최단거리를 구해줘야 하는데, 이는 입력을 받을 때 역방향 간선도 입력을 받은 후, 그 간선들을 이용해서 파티가 열린 마을에서 다익스트라를 해주면 구할 수 있다.
위에서 구한 값의 두 값의 합이 가장 큰 곳이 가장 시간이 오래 걸리는 마을이다.
단순한 다익스트라 구현이라 설명할 내용이 크게 없을 것 같다.


### 🥝 최악 수행 시간 복잡도

~~O(N*N*logM) (다익스트라를 N번 실행)~~
다익스트라 2번으로 해결이 되므로 O(M*logN) 시간으로 해결이 가능하다.
<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
-----------------------------------------------------------------
소희님의 의견을 받아서 코드 수정을 해봤는데, 꽤 유의미한 정도로 시간이 줄었네요. 피드백 감사합니다!
![image](https://user-images.githubusercontent.com/83604180/179216567-5c726612-7ca5-4c00-b528-7d069d0b3328.png)
