### PR TITLE
[BOJ] 나무 위의 빗물

### DIFF
--- a/BOJ/나무 위의 빗물/박예찬.cpp
+++ b/BOJ/나무 위의 빗물/박예찬.cpp
@@ -1,0 +1,49 @@
+#include<iostream>
+#include<vector>
+using namespace std;
+double arr[500001];
+vector<int> v[500001];
+int n, w;
+bool flag[500001];
+void dfs(int n) {
+	flag[n] = true;
+	bool meet = false;
+	int counter = 0;
+	for (int i = 0; i < v[n].size(); i++) {
+		if (!flag[v[n][i]]) {
+			counter++;
+		}
+	}
+	double cur = arr[n] / counter;
+	for (int i = 0; i < v[n].size(); i++) {
+		if (!flag[v[n][i]]) {
+			meet = true;
+			arr[v[n][i]] = cur;
+			dfs(v[n][i]);
+		}
+	}
+	if (meet) {
+		arr[n] = 0;
+	}
+}
+int main() {
+	cin >> n >> w;
+	for (int i = 0; i < n - 1; i++) {
+		int x, y;
+		cin >> x >> y;
+		v[x].push_back(y);
+		v[y].push_back(x);
+	}
+	arr[1] = w;
+	dfs(1);
+	double sum = 0;
+	int counter = 0;
+	for (int i = 1; i <= n; i++) {
+		if (arr[i] != 0) {
+			//cout << i << ' ' << arr[i] << endl;
+			sum += arr[i];
+			counter++;
+		}
+	}
+	cout << fixed<<sum / counter;
+}


### PR DESCRIPTION
DFS를 이용해 문제 해결

<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #62 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
Input : N(노드의 개수), W(1번 노드에 고여잇는 빗물)
이후 N-1개의 줄 동안
U, V (U와 V를 잇는 간선이 존재함을 의미)

Output : 물이 고여있는 양이 0보다 큰 모든 노드에 빗물의 기댓값의 평균

<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계

dfs를 통해 1번노드부터 아래로 현재 노드에 있는 물의 양/현재 노드의 자식 노드 만큼을 흘러 내려보내준다.
이후 흘러내려 보내줬다면 현재 노드에 있는 비의 양을 0으로 초기화 해준다.
이러한 방식으로 모든 leaf노드에게 도달하면 leaf노드에 있는 빗물의 양의 평균을 구해주면 된다.

### 🥝 최악 수행 시간 복잡도
O(N)

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
구현을 다 했지만, 구현을 다 하고 보니 결국 leaf노드에 모든 빗물이 가게 되고, 빗물의 총 합은 고정이기떄문에
답은 결국 
<b>빗물의 양/ 리프 노드의 개수</b>
라는 사실을 깨달았다.