### PR TITLE
[BOJ]  확장 게임

### DIFF
--- a/BOJ/확장 게임/박상민.cpp
+++ b/BOJ/확장 게임/박상민.cpp
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <queue>
+#include <memory.h>
+using namespace std;
+
+struct el{
+  int row, col, stage;
+};
+
+int N, M, P;
+char board[1000][1000];
+queue<struct el> bfs[10];
+int s[10];
+int res[10];
+pair<int, int> dir[4] = {{0,1},{1,0},{0,-1},{-1,0}};
+
+bool range_check(struct el curr){
+  int row = curr.row;
+  int col = curr.col;
+  if(row >= N || row < 0 || col >= M || col < 0)
+    return false;
+  if(board[row][col] != '.')
+    return false;
+  return true;
+}
+
+
+int main(){
+  cin >> N >> M >> P;
+  for(int pdx = 1; pdx <= P; pdx++)
+    cin >> s[pdx];
+  for(int ndx = 0; ndx < N; ndx++){
+    for(int mdx = 0; mdx < M; mdx++){
+      cin >> board[ndx][mdx];
+      char tmp = board[ndx][mdx];
+      if(tmp >= '1' && tmp <= '9')
+        bfs[tmp-'1'+1].push({ndx, mdx, 0});
+    }
+  }
+  while(true){
+    bool flag = false;
+    for(int pdx = 1; pdx <= P; pdx++){
+      int curr_stage = bfs[pdx].front().stage;
+      while(!bfs[pdx].empty() && bfs[pdx].front().stage < curr_stage + s[pdx]){
+        struct el curr = bfs[pdx].front();
+        bfs[pdx].pop();
+        for(int ddx = 0; ddx < 4; ddx++){
+          struct el next = {curr.row + dir[ddx].first, curr.col + dir[ddx].second, curr.stage + 1};
+          if(!range_check(next))
+            continue;
+          board[next.row][next.col] = '0' + pdx;
+          bfs[pdx].push(next);
+          flag = true;
+        }
+      }
+    }
+    if(!flag)
+      break;
+  }
+
+  memset(res, 0, sizeof(res));
+  for(int ndx = 0; ndx < N; ndx++){
+    for(int mdx = 0; mdx < M; mdx++){
+      char tmp = board[ndx][mdx];
+      if(tmp >= '1' && tmp <= '9')
+        res[tmp-'1'+1]++;
+    }
+  }
+
+  for(int pdx = 1; pdx <= P; pdx++)
+    cout << res[pdx] << ' ';
+}


### PR DESCRIPTION
<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #64 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
Input
- 첫째 줄에 격자판의 크기 N, M과 플레이어 수 P가 주어짐
- 둘째 줄에 S1....Sp가 주어짐
- 다음 N개의 줄에는 게임판의 상태가 주어짐
- 1 ≤ N, M ≤ 1,000
- 1 ≤ P ≤ 9
- 1 ≤ Si ≤ 109

Output
- 게임이 종료되었을 때 각 플레이어가 차지한 칸의 수

<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계
BFS queue를 플레이어 수만큼 만든 뒤, 차례대로 순회하며 게임판의 상태를 변경했습니다. 

마지막에 게임판을 for문으로 순회하며 최종 상태를 카운트했는데, BFS 서치시 새로운 칸을 찾을 때마다 세어주는 식으로 하면 마지막 더블 for문을 생략할 수 있을 것 같습니다. 


### 🥝 최악 수행 시간 복잡도
O(N * M)

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
입력을 받을 때, 
 char board[N][M]
  for(int ndx = 0; ndx < N; ndx++)
    cin >> board[ndx];
이런 식으로 입력을 받으면 백준 채점 상에서 인식되지 않던데, 혹시 이유가 뭔지 아시는 분 계실까요?





