### PR TITLE
[BOJ] 확장 게임

### DIFF
--- a/BOJ/확장 게임/김소희.cpp
+++ b/BOJ/확장 게임/김소희.cpp
@@ -1,0 +1,108 @@
+//
+// Created by Kim So Hee on 2022/07/15.
+//
+
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int N, M, P;
+int inputs[1001][1001];
+int depth[10];
+int dx[4]{0, 1, 0, -1};
+int dy[4]{-1, 0, 1, 0};
+
+struct Cord {
+    int y;
+    int x;
+    int player;
+    int limit;
+};
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+    cout.tie(nullptr);
+
+    vector<vector<pair<int, int>>> castles(10);
+    cin >> N >> M >> P;
+    for (int i = 1; i <= P; ++i) {
+        cin >> depth[i];
+    }
+    for (int i = 0; i < N; ++i) {
+        for (int j = 0; j < M; ++j) {
+            char c;
+            cin >> c;
+            if (c == '.') inputs[i][j] = 0;
+            else if (c == '#') inputs[i][j] = -1;
+            else {
+                int number = c - '0';
+                inputs[i][j] = number;
+                castles[number].push_back({i, j});
+            }
+        }
+    }
+
+    queue<Cord> q;
+    for (int i = 1; i < castles.size(); i++) {
+        for (const auto &castle: castles[i]) {
+            q.push({castle.first, castle.second, i, depth[i]});
+        }
+    }
+
+    while (!q.empty()) {
+        /**
+         * Si는 BFS의 depth 제한이다
+         * Player마다 돌아가면서 가능한 depth 단위(Si)로 BFS를 실행한다
+         *
+         * 바깥의 큐는 플레이어 턴의 실행 대기열이다
+         *  - 큐가 empty, 즉 확장을 더 이상 할 수 없을 때 종료한다
+         *
+         * 안쪽의 큐는 플레이어 하나 당 실행하는 BFS 큐이다
+         *  - 플레이어 당 제한된 depth 만 실행한다
+         *  - 0인 칸만 확장할 수 있다
+         *  - 마지막 depth 탐색 시, 다음 탐색할 칸을 바깥 큐에 넣는다
+         */
+        int player = q.front().player;
+        queue<Cord> run;
+        while (!q.empty() && q.front().player == player) {
+            auto here = q.front();
+            run.push(here);
+            q.pop();
+            if (inputs[here.y][here.x] == 0)
+                inputs[here.y][here.x] = player;
+        }
+
+        // BFS 실행
+        while (!run.empty()) {
+            auto [y, x, p, limit] = run.front();
+            run.pop();
+
+            for (int i = 0; i < 4; ++i) {
+                int nextY = y + dy[i], nextX = x + dx[i];
+                /**
+                 * 1. 인덱스 범위 처리, 방문 예외 처리
+                 * 2. 0 인 칸만 방문
+                 * 3. limit 가 1 이면 바깥 큐에 삽입 (턴 종료)
+                 */
+                if (nextY < 0 || nextX < 0 || nextY >= N || nextX >= M) continue;
+                if (inputs[nextY][nextX] != 0) continue;
+                inputs[nextY][nextX] = player;
+
+                if (limit == 1) q.push({nextY, nextX, player, depth[player]});
+                else {
+                    run.push({nextY, nextX, player, limit - 1});
+                }
+            }
+        }
+    }
+    vector<int> answer(P);
+    for (int i = 0; i < N; ++i) {
+        for (int j = 0; j < M; ++j) {
+            if (inputs[i][j] >= 1) answer[inputs[i][j] - 1]++;
+        }
+    }
+    for (const auto &a: answer) {
+        cout << a << ' ';
+    }
+}


### PR DESCRIPTION

<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #64



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
`input`
 - 격자판 크기 (1 ≤ N, M ≤ 1,000), 게임판 상태
 - 플레이어 수 P, 확장 거리 S
  
 `output`
 - 각 플레이어의 성 개수


<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계
플레이어마다 **depth 제한을 두어 BFS를 실행**했습니다
 - 마지막 depth일 때 다음에 방문할 칸을 대기열 큐에 삽입합니다

큐를 2개 생성했었는데, 플레이어마다 1개씩 총 9개를 생성했다면 조금 더 깔끔한 코드가 되었을 것 같습니다
 - 대기 중인 플레이어들의 BFS 큐
 - 턴 진행 중인 플레이어의 BFS 큐



### 🥝 최악 수행 시간 복잡도
 - `O(NM)`


<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)

