### PR TITLE
[BOJ] 부분합

### DIFF
--- a/BOJ/부분합/박에찬.CPP
+++ b/BOJ/부분합/박에찬.CPP
@@ -1,0 +1,36 @@
+#include<iostream>
+#include<vector>
+#include<queue>
+#include<algorithm>
+#include<tuple>
+#include<string>
+using namespace std;
+int n,s;
+int arr[100001];
+int minLength;
+int minValue;
+int sum, counter;
+int main() {
+	ios_base::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+	cin >> n >> s;
+	for (int i = 1; i <= n; i++)cin >> arr[i];
+	int leftIdx=1;
+	int rightIdx = 1;
+	sum =arr[1];
+	minLength = n + 1;
+	while (rightIdx<=n&&rightIdx>=leftIdx) {	
+		//cout << sum << endl;
+		if (sum >= s) {
+			minLength = min(minLength, rightIdx - leftIdx+1);
+			sum -= arr[leftIdx];
+			leftIdx++;
+		}
+		else {
+			rightIdx++;
+			sum += arr[rightIdx];
+			
+		}
+	}
+	if (minLength == n + 1)minLength = 0;
+	cout << minLength;
+}


### PR DESCRIPTION
투포인터를 활용하여 문제 해결

<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #88 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
Input :
N(원소의 개수) S
N개의 원소

Output : 배열의 연속의 합이 s이상인 배열의 최소 길이 


<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계
투포인터를 활용해 문제를 해결하였다.
먼저, 인덱스의 앞을 나타내는 부분과 뒤를 나타내는 부분을 나누는데, 현재까지의 배열의 합이 S보다 <b>크다면</b> 앞부분을 1칸 뒤로, 배열의 합이 S보다 <b>작다면</b> 뒷부분을 1칸 뒤로 해준다.
이후, 조건이 만족하는 S보다 클 때의 길이,즉 뒷부분의 idx와 앞부분의 idx의 차가 가장 짧은 값을 구하면 된다.


### 🥝 최악 수행 시간 복잡도
O(N)

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
