### PR TITLE
[BOJ] 트리의 지름

### DIFF
--- a/BOJ/트리의 지름/박예찬.cpp
+++ b/BOJ/트리의 지름/박예찬.cpp
@@ -1,0 +1,60 @@
+#include<iostream>
+#include<queue>
+#include<cmath>
+#include<string>
+#include<stack>
+#include<vector>
+using namespace std;
+int n;
+vector<pair<int, int>> con[100001];
+bool flag[100001];
+int dis[100001];
+void dfs(int a) {
+	flag[a] = true;
+	for (int i = 0; i < con[a].size(); i++) {
+		if (flag[con[a][i].first] == false)
+		{
+			dis[con[a][i].first] = dis[a] + con[a][i].second;
+			dfs(con[a][i].first);
+		}
+	}
+
+}
+int main() {
+	ios::sync_with_stdio(false);
+	cin >> n;
+	int x, y, d;
+	for (int i = 0; i < n; i++) {
+		cin >> x >> y;
+		while (y != -1) {
+			cin >> d;
+			con[x].push_back({ y,d });
+			con[y].push_back({ x,d });
+			cin >> y;
+		}
+
+	}
+	int maxD = 0;
+	int maxN = 0;
+	dis[1] = 0;
+	dfs(1);
+	for (int i = 1; i <= n; i++) {
+		if (dis[i] > maxD) {
+			maxD = dis[i];
+			maxN = i;
+		}
+	}
+	for (int i = 1; i <= n; i++) {
+		flag[i] = false;
+		dis[i] = 0;
+	}
+	dfs(maxN);
+	for (int i = 1; i <= n; i++) {
+		if (dis[i] > maxD) {
+			maxD = dis[i];
+			maxN = i;
+		}
+	}
+	cout << maxD;
+
+}


### PR DESCRIPTION
DFS를 활용하여 문제 해결

<!--
✅ 제목 : [플랫폼] 문제_이름
     ☑ [BOJ] : 백준
     ☑ [PGS] : 프로그래머스
     ☑ [CFS] : 코드포스
     ☑ [LCE] : 리트코드
     ☑ [ETC] : 그 외 사이트
ex) [BOJ] 트리의 순회

✅ 라벨 : Review Request / Merge Request
     ☑ Review Request: 리뷰 요청 시 사용
     ☑ Merge Request: 리뷰 사항을 모두 적용한 후, main branch에 병합 요청 시 사용
-->



<!--
✅ {#이슈번호} 부분을 해결한 문제의 이슈번호로 변경해 주세요.
ex) #12

✅ PR 등록 후, 우측 하단에 이슈가 제대로 연결되었는지 확인해 주세요.
-->
### 🍪 문제 번호
Resolve: #85 



<!--
✅ 문제를 간단하게 정의해 주세요.
     ☑ input 정의(입력 제한, 특징 등)
        ex) 전체 용액의 수 N[2, 1e5], 오름차순으로 정렬된 서로 다른 용액의 특성값[-1e9, 1e9]
     ☑ output 정의
        ex) 첫째 줄에 특성값이 0에 가장 가까운 용액을 만들어 내는 두 용액의 특성값을 오름차순으로 출력
            특성값이 0에 가장 가까운 용액을 만들어 내는 경우가 두 개 이상일 경우에는 그 중 아무 것이나 출력
-->
### 🍊 문제 정의
Input : 
N,
이후 N개의 줄에 대해서 간선 정보
Output :
점 사이가 가장 긴 두 점 사이의 거리


<!--
✅ 문제를 해결하기 위해 설계한 알고리즘을 설명해 주세요.
     ☑ 코드를 이해할 수 있을 정도로만 간략하게 작성해 주세요.
     ☑ 사용한 알고리즘과 자료구조, 로직 등을 편하신 방법으로 설명해 주세요.
     ☑ 알고리즘 및 자료구조에 대한 설명은 생략해 주세요.
        ex) quick sort의 구조 및 동작 원리 ❌
-->
### 🍑 알고리즘 설계
두 번의 DFS를 통해 문제를 해결하였다.
먼저, 임의로 한 점을 선정하여 그 점에서부터 DFS로 노드마다 거리를 구한다. (내 코드에서는 1번 노드)
그 결과, 가장 멀리 떨어져 있는 점이 항상 트리의 양 끝 점 중 한 곳이다.
이 점을 구하고, 이 점에서 다시 DFS로 노드마다 거리를 구하면, 가장 멀리 떨어져 있는 점이 다른 하나의 끝 점이다.
따라서, 가장 멀리있는 점과의 거리가 트리의 지름이라고 할 수 있다.


### 🥝 최악 수행 시간 복잡도
O(N+E)

<!--
✅ 특별히 리뷰를 받고 싶은 부분이나, 코드를 읽기 전 참고할 사항을 작성해 주세요.
✅ 참고한 포스팅이나 레퍼런스가 있다면, 여기에 작성해 주세요.
-->
### 🍰 특이 사항 (Optional)
